### PR TITLE
WASD movement fixes. Resize band-aid fix.

### DIFF
--- a/dist/vim-3d-viewer.js
+++ b/dist/vim-3d-viewer.js
@@ -1053,9 +1053,10 @@ vim3d.view = function (options) {
 
     // Use this when in full frame mode.
     function onWindowResize() {
-        var rect = renderer.domElement.getBoundingClientRect();
-        camera.aspect = rect.width / rect.height;
-        camera.updateProjectionMatrix();
+        // Code currently disabled; projection matrix update here breaks the view.
+        // var rect = renderer.domElement.getBoundingClientRect();
+        // camera.aspect = rect.width / rect.height;
+        // camera.updateProjectionMatrix();
     }
 
     function getEventMouseCoordinates(event) {
@@ -54372,7 +54373,7 @@ THREE.OrbitControls = function (object, domElement) {
     this.enableKeys = true;
 
     // The four arrow keys
-    this.keys = { LEFT: 65, RIGHT: 68, UP: 81, DOWN: 69, IN: 87, OUT: 83 };
+    this.keys = { LEFT: 65, RIGHT: 68, UP: 81, DOWN: 69, IN: 83, OUT: 87 };
 
     // Mouse buttons
     this.mouseButtons = { LEFT: THREE.MOUSE.ROTATE, MIDDLE: THREE.MOUSE.DOLLY, RIGHT: THREE.MOUSE.PAN };

--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
                 },
                 showStats: false,
                 showGui: true,
+                guiClosed: true,
                 SSAO: {
                     enable: false,
                     kernelRadius: 0.07,

--- a/js/CustomOrbitControls.js
+++ b/js/CustomOrbitControls.js
@@ -75,7 +75,7 @@ THREE.OrbitControls = function (object, domElement) {
     this.enableKeys = true;
 
     // The four arrow keys
-    this.keys = { LEFT: 65, RIGHT: 68, UP: 81, DOWN: 69, IN: 87, OUT: 83 };
+    this.keys = { LEFT: 65, RIGHT: 68, UP: 81, DOWN: 69, IN: 83, OUT: 87 };
 
     // Mouse buttons
     this.mouseButtons = { LEFT: THREE.MOUSE.ROTATE, MIDDLE: THREE.MOUSE.DOLLY, RIGHT: THREE.MOUSE.PAN };

--- a/js/CustomOrbitControls.js
+++ b/js/CustomOrbitControls.js
@@ -75,7 +75,7 @@ THREE.OrbitControls = function (object, domElement) {
     this.enableKeys = true;
 
     // The four arrow keys
-    this.keys = { LEFT: 65, RIGHT: 68, UP: 81, DOWN: 69, IN: 83, OUT: 87 };
+    this.keys = { LEFT: 65, RIGHT: 68, UP: 81, BOTTOM: 69, IN: 83, OUT: 87 };
 
     // Mouse buttons
     this.mouseButtons = { LEFT: THREE.MOUSE.ROTATE, MIDDLE: THREE.MOUSE.DOLLY, RIGHT: THREE.MOUSE.PAN };
@@ -333,6 +333,20 @@ THREE.OrbitControls = function (object, domElement) {
 
     }
 
+    var panForward = function() {
+
+        var v = new THREE.Vector3();
+
+        return function panForward(distance, objectMatrix) {
+
+            v.setFromMatrixColumn(objectMatrix, 2); // get Y column of objectMatrix
+            v.multiplyScalar(- distance * 0.25); // 0.25 fudge factor
+
+            panOffset.add(v);
+
+        };
+    }();
+
     var panLeft = function () {
 
         var v = new THREE.Vector3();
@@ -418,7 +432,7 @@ THREE.OrbitControls = function (object, domElement) {
 
         if (scope.object.isPerspectiveCamera) {
 
-            scale /= dollyScale;
+            panForward(-dollyScale, scope.object.matrix);
 
         } else if (scope.object.isOrthographicCamera) {
 
@@ -439,7 +453,7 @@ THREE.OrbitControls = function (object, domElement) {
 
         if (scope.object.isPerspectiveCamera) {
 
-            scale *= dollyScale;
+            panForward(dollyScale, scope.object.matrix);
 
         } else if (scope.object.isOrthographicCamera) {
 
@@ -540,13 +554,15 @@ THREE.OrbitControls = function (object, domElement) {
 
     function handleMouseWheel(event) {
 
+        const mouseWheelMultiplier = 2;
+
         if (event.deltaY < 0) {
 
-            dollyOut(getZoomScale());
+            dollyOut(getZoomScale() * mouseWheelMultiplier);
 
         } else if (event.deltaY > 0) {
 
-            dollyIn(getZoomScale());
+            dollyIn(getZoomScale() * mouseWheelMultiplier);
 
         }
 
@@ -726,7 +742,17 @@ THREE.OrbitControls = function (object, domElement) {
 
         dollyDelta.set(0, Math.pow(dollyEnd.y / dollyStart.y, scope.zoomSpeed));
 
-        dollyIn(dollyDelta.y);
+        if (Math.abs(dollyDelta.y - 1) > 0.01) // only dolly if the movement exceeds an epsilon value.
+        {
+            if (dollyDelta.y < 1) {
+
+                dollyIn(dollyDelta.y);
+    
+            } else {
+    
+                dollyOut(dollyDelta.y);
+            }
+        }
 
         dollyStart.copy(dollyEnd);
 

--- a/js/index.js
+++ b/js/index.js
@@ -566,7 +566,6 @@ vim3d.view = function (options) {
         controls.rotateSpeed = settings.camera.controls.rotateSpeed;
         controls.enablePan = settings.camera.controls.enablePan;
         controls.panSpeed = settings.camera.controls.panSpeed;
-        controls.screenSpacePanning = settings.camera.controls.screenSpacePanning;
         controls.keySpanSpeed = settings.camera.controls.pixelPerKeyPress;
         controls.zoomSpeed = settings.camera.controls.zoomSpeed;
         controls.screenSpacePanning = settings.camera.controls.screenSpacePanning;
@@ -919,6 +918,7 @@ vim3d.view = function (options) {
         if (settings.showGui) {
             // Create a new DAT.gui controller
             gui = new dat.GUI({ autoPlace: false, closeOnTop: true, scrollable: true });
+            gui.closed = !!settings.guiClosed;
             document.getElementById("datguicontainer").appendChild(gui.domElement);
             // Bind the properties to the DAT.gui controller, returning the scene when it updates
             bindControls(props, gui, function () {

--- a/js/index.js
+++ b/js/index.js
@@ -1053,9 +1053,10 @@ vim3d.view = function (options) {
 
     // Use this when in full frame mode.
     function onWindowResize() {
-        var rect = renderer.domElement.getBoundingClientRect();
-        camera.aspect = rect.width / rect.height;
-        camera.updateProjectionMatrix();
+        // Code currently disabled; projection matrix update here breaks the view.
+        // var rect = renderer.domElement.getBoundingClientRect();
+        // camera.aspect = rect.width / rect.height;
+        // camera.updateProjectionMatrix();
     }
 
     function getEventMouseCoordinates(event) {


### PR DESCRIPTION
- Dolly movement now pans the camera forward instead of zooming it.
- Closing the dat.GUI panel by default.
- Band-aid fix for the resizing. The renderer sizing and camera aspect ratio code is extremely finicky - I couldn't for the life of me figure out the correct fix despite attempting numerous approaches I could find on the internet.